### PR TITLE
Fapolicyd IMA integrity check scenario

### DIFF
--- a/Plans/ima-integrity.fmf
+++ b/Plans/ima-integrity.fmf
@@ -1,0 +1,21 @@
+summary: run fapolicyd with IMA integrity check
+
+
+prepare:
+  - how: shell
+    script:
+    - rpm -Uv https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm || true
+    when: distro == rhel-9 or distro == centos-stream-9
+
+discover:
+  - name: Configure_simple_IMA_policy
+    how: fmf
+    test:
+      - /Setup/configure_kernel_ima_module
+  - name: Run_fapolicyd_IMA_integrity_check
+    how: fmf
+    test:
+      - /Sanity/integrity-advanced
+
+execute:
+    how: tmt

--- a/Sanity/integrity-advanced/main.fmf
+++ b/Sanity/integrity-advanced/main.fmf
@@ -1,9 +1,11 @@
-summary: Test for BZ#1887451 (Rebase FAPOLICYD to the latest upstream version)
+summary: Fapolicyd use IMA integrity check
 description: |
+    Scenario where fapolicyd use as integrity check IMA policy.
+    Needed provided setup of IMA policy before test.
     Bug summary: Rebase FAPOLICYD to the latest upstream version
     Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=1887451
 contact:
-- Dalibor Pospisil <dapospis@redhat.com>
+- Patrik Koncity <pkoncity@redhat.com>
 component:
 - fapolicyd
 test: ./runtest.sh
@@ -11,7 +13,7 @@ require+:
 - fapolicyd
 - library(ControlFlow/Cleanup)
 - library(distribution/testUser)
-enabled: false
+- attr
 duration: 5m
 extra-summary: /CoreOS/fapolicyd/Sanity/integrity
 extra-task: /CoreOS/fapolicyd/Sanity/integrity

--- a/Sanity/integrity-advanced/runtest.sh
+++ b/Sanity/integrity-advanced/runtest.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /fapolicyd/Sanity/integrity-advanced
+#   Description: Test for BZ#1887451 (Rebase FAPOLICYD to the latest upstream version)
+#   Author: Patrik Koncity <pkoncity@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2023 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="fapolicyd"
+
+set_config_option() {
+  local file=/etc/fapolicyd/fapolicyd.conf
+  sed -i -r "/^$1 =/d"   $file
+  [[ -n "$2" ]] && {
+    echo           >> $file
+    echo "$1 = $2" >> $file
+  }
+  echo "# grep$numbers -v -e '^\s*#' -e '^\s*$' \"$file\""
+  grep$numbers -v -e '^\s*#' -e '^\s*$' "$file"
+  echo "---"
+}
+
+# $1 - command
+# $2 - expected result, default 0
+uRun() {
+  rlRun "timeout 2 su - $testUser -c \"$1\"" ${2:-0}
+}
+
+rlJournalStart && {
+  rlPhaseStartSetup && {
+    rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+    rlRun "rlCheckMakefileRequires" || rlDie "cannot continue"
+    rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+    CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
+    CleanupRegister 'rlRun "popd"'
+    rlRun "pushd $TmpDir"
+    rlRun "chmod -R a+rwx $TmpDir"
+    CleanupRegister 'rlRun "testUserCleanup"'
+    rlRun "testUserSetup"
+    CleanupRegister 'fapCleanup'
+    rlRun "fapSetup"
+    fapPrepareTestPackages
+    CleanupRegister 'rlRun "rpm -e fapTestPackage"'
+    rlRun "rpm -ivh ${fapTestPackage[1]}"
+    cat $fapTestProgram > fapTestProgram
+    rlRun "rpm -e fapTestPackage"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "functionality check" && {
+    rlRun "cp /bin/ls ./"
+    CleanupRegister --mark 'rlRun "fapStop"'
+    rlRun "fapStart --debug"
+    uRun "$TmpDir/ls" 126
+    CleanupDo --mark
+    rlRun "fapServiceOut -t"
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "integrity none" && {
+    # any binary in the trusted path should work
+    rlRun "rpm -ivh --force $fapTestPackage"
+    set_config_option integrity 'none'
+    CleanupRegister --mark 'rlRun "fapStop"'
+    rlRun "fapStart"
+    uRun "$fapTestProgram" 124
+    rlRun "cat fapTestProgram > $fapTestProgram"
+    uRun "$fapTestProgram" 124
+    rlRun "cat /bin/ls > $fapTestProgram"
+    uRun "$fapTestProgram"
+    CleanupDo --mark
+  rlPhaseEnd; }
+
+  rlPhaseStartTest "integrity ima" && {
+    rlRun "rpm -ivh --force $fapTestPackage"
+    HASH=($(sha256sum ${fapTestProgram}))
+    sleep 5
+    set_config_option integrity 'IMA'
+    CleanupRegister --mark 'rlRun "fapStop"'
+    #label IMA to all files file attr
+    find / -fstype ext4 -type f -uid 0 -exec dd if='{}' of=/dev/null count=0 status=none \;
+    rlRun "fapStart --debug"
+    uRun "$fapTestProgram" 124
+    rlRun -s "getfattr -m - -d -e hex /usr/local/bin/fapTestProgram | grep ${HASH}"
+    rlRun "cat fapTestProgram > $fapTestProgram"
+    uRun "$fapTestProgram" 126
+    rlRun "cat /bin/ls > $fapTestProgram"
+    uRun "$fapTestProgram" 126
+    CleanupDo --mark
+    rlRun "fapServiceOut -t"
+  rlPhaseEnd; }
+
+  rlPhaseStartCleanup && {
+    CleanupDo
+  rlPhaseEnd; }
+  rlJournalPrintText
+rlJournalEnd; }

--- a/Setup/configure_kernel_ima_module/main.fmf
+++ b/Setup/configure_kernel_ima_module/main.fmf
@@ -1,0 +1,18 @@
+summary: Configures kernel ima module on a running system
+description: Enables kernel_ima on a tested system
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+- keylime
+test: ./runtest.sh
+tag:
+- setup
+framework: beakerlib
+require:
+- grubby
+- openssl
+duration: 10m
+enabled: true
+adjust:
+  - when: distro == rhel-8 or distro = centos-stream-8
+    enabled: false
+    because: RHEL-8 has old kernel

--- a/Setup/configure_kernel_ima_module/runtest.sh
+++ b/Setup/configure_kernel_ima_module/runtest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+[ -z "${IMA_APPRAISE}" ] && IMA_APPRAISE="fix"
+[ -z "${IMA_POLICY}" ] && IMA_POLICY="tcb"
+[ -z "${IMA_HASH}" ] && IMA_HASH="sha256"
+[ -z "${IMA_AUDIT}" ] && IMA_AUDIT="1"
+
+COOKIE=/var/tmp/configure-kernel-ima-module-rebooted
+TESTFILE=/var/tmp/configure-kernel-ima-module-test$$
+
+rlJournalStart
+
+  if [ ! -e $COOKIE ]; then
+    rlPhaseStartSetup "pre-reboot phase"
+        rlRun "grubby --info ALL"
+        rlRun "grubby --default-index"
+        rlRun "grubby --update-kernel DEFAULT --args 'ima_appraise=${IMA_APPRAISE} ima_appraise_tcb ima_policy=${IMA_POLICY} ima_hash=${IMA_HASH} ima_audit=${IMA_AUDIT}'" 
+        rlRun -s "grubby --info DEFAULT | grep '^args'"
+        rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
+        rlAssertGrep "ima_policy=${IMA_POLICY}" $rlRun_LOG
+	rlAssertGrep "ima_audit=${IMA_AUDIT}" $rlRun_LOG
+	rlAssertGrep "ima_hash=${IMA_HASH}" $rlRun_LOG
+    	rlRun "touch $COOKIE"
+    rlPhaseEnd
+
+    rhts-reboot
+
+  else
+    rlPhaseStartTest "post-reboot IMA test"
+        rlRun -s "cat /proc/cmdline"
+        rlAssertGrep "ima_appraise=${IMA_APPRAISE}" $rlRun_LOG
+        rlAssertGrep "ima_policy=${IMA_POLICY}" $rlRun_LOG
+        rlAssertGrep "ima_audit=${IMA_AUDIT}" $rlRun_LOG
+        rlAssertGrep "ima_hash=${IMA_HASH}" $rlRun_LOG
+	rlRun "grubby --info ALL"
+        rlRun "grubby --default-index"
+        rlRun "rm $COOKIE" 
+        if [ "${IMA_STATE}" == "on" -o "${IMA_STATE}" == "1" ]; then
+            rlRun "touch ${TESTFILE} && cat ${TESTFILE} && rm ${TESTFILE}"
+            rlRun "grep ${TESTFILE} /sys/kernel/security/ima/ascii_runtime_measurements"
+        fi
+    rlPhaseEnd
+  fi
+
+rlJournalEnd


### PR DESCRIPTION
Fapolicyd use for integrity check hashes
generated by IMA. Create new scenario for IMA
integrity check and new setup task which set up
IMA policy.

https://github.com/RedHat-SP-Security/tests/pull/125 