### PR TITLE
Disable memleak test for ppc64le arch

### DIFF
--- a/Sanity/memleaks/main.fmf
+++ b/Sanity/memleaks/main.fmf
@@ -18,6 +18,9 @@ adjust+:
   - enabled: false
     when: distro < rhel-8.4
     continue: false
+  - when: arch == ppc64le
+    enabled: false
+    because: Valgrind functionality missing on ppc64le
 link:
   - verifies: https://issues.redhat.com/browse/RHEL-519
   - verifies: https://issues.redhat.com/browse/RHEL-430


### PR DESCRIPTION
Due missing valgrind functionality for ppc64le
arch memleak tests failed.