### PR TITLE
Disable IMA integrity test for RHEL-8

### DIFF
--- a/Sanity/integrity-advanced/main.fmf
+++ b/Sanity/integrity-advanced/main.fmf
@@ -19,5 +19,6 @@ extra-summary: /CoreOS/fapolicyd/Sanity/integrity
 extra-task: /CoreOS/fapolicyd/Sanity/integrity
 extra-nitrate: TC#0609439
 adjust+:
-  - enabled: false
-    when: distro < rhel-8.4
+  - when: distro == rhel-8 or distro = centos-stream-8
+    enabled: false
+    because: RHEL-8 has old kernel and IMA setup is disabled


### PR DESCRIPTION
Required IMA setup is able to provide just for
RHEL-9 because, RHEL-8 has old kernel which not
supporting this IMA setup.