### PR TITLE
Adjust test to pass upstream CI

### DIFF
--- a/Regression/rpmdb-ownership/main.fmf
+++ b/Regression/rpmdb-ownership/main.fmf
@@ -12,6 +12,9 @@ tier: '3'
 adjust+:
   - enabled: false
     when: distro < rhel-8.2
+adjust:
+    enabled: false
+    when: initiator == packit and distro == centos-stream-8
 link:
     verifies: https://issues.redhat.com/browse/RHEL-829
 extra-nitrate: TC#0615601

--- a/Sanity/selinux/runtest.sh
+++ b/Sanity/selinux/runtest.sh
@@ -75,8 +75,13 @@ rlJournalStart && {
       rlSEMatchPathCon "/var/log/fapolicyd-access.log" "fapolicyd_log_t"
       rlSEMatchPathCon "/var/lib/fapolicyd" "fapolicyd_var_lib_t"
       rlSEMatchPathCon "/var/lib/fapolicyd/data.mdb" "fapolicyd_var_lib_t"
-      rlSEMatchPathCon "/var/run/fapolicyd/fapolicyd.fifo" "fapolicyd_var_run_t"
-      rlSEMatchPathCon "/var/run/fapolicyd.pid" "fapolicyd_var_run_t"
+      if rlIsRHEL "<10" || rlIsFedora "<40"; then
+           rlSEMatchPathCon "/var/run/fapolicyd/fapolicyd.fifo" "fapolicyd_var_run_t"
+           rlSEMatchPathCon "/var/run/fapolicyd.pid" "fapolicyd_var_run_t"
+      else
+           rlSEMatchPathCon "/var/run/fapolicyd/fapolicyd.fifo" "fapolicyd_run_t"
+           rlSEMatchPathCon "/var/run/fapolicyd.pid" "fapolicyd_run_t"
+      fi
     rlPhaseEnd; }
 
     rlPhaseStartTest "policy rules" && {


### PR DESCRIPTION
From Fedora rawhide version, fapolicyd
SELinux policy changed context /var/run
path. Adjusting test to reflect
changes. Also disabling rpmdb test for
packit CI and specific distros.