### PR TITLE
Add 'component:rpm' into TC's metadata

### DIFF
--- a/Sanity/dnf-yum-rpm-plugin/main.fmf
+++ b/Sanity/dnf-yum-rpm-plugin/main.fmf
@@ -12,6 +12,8 @@ require+:
   - /usr/bin/time
 duration: 25m
 enabled: true
+component:
+  - rpm
 tag:
   - Tier1
   - rhel-8.4.0


### PR DESCRIPTION
Needed for dynamic test filtering in NEWA automation.