### PR TITLE
TESTING: Remove selinux policy common as lib dependency

### DIFF
--- a/Library/common/lib.sh
+++ b/Library/common/lib.sh
@@ -69,7 +69,7 @@ fapSetup() {
   rlRun "rlServiceStop fapolicyd"
   rlRun "rlFileBackup --namespace fap --clean /etc/fapolicyd/ /etc/systemd/system/fapolicyd.service.d"
   rlRun "rm -f /var/lib/fapolicyd/*"
-  rlRun "rlSEBooleanOn --namespace fap daemons_use_tty"
+  rlRun "setsebool daemons_use_tty on"
   if [[ -z "$(sesearch -A -s init_t -t unconfined_t -c fifo_file -p write)" ]]; then
     cat > mujfamodul.te <<EOF
 policy_module(mujfamodul,1.0)
@@ -98,7 +98,7 @@ fapCleanup() {
     systemctl daemon-reload
   }
   [[ -n "${fapolicyd_out[*]}" ]] && rm -f "${fapolicyd_out[@]}"
-  rlRun "rlSEBooleanRestore --namespace fap"
+  rlRun "setsebool daemons_use_tty off"
   rlRun "rlFileRestore --namespace fap"
   rlRun "rlServiceRestore fapolicyd"
 }

--- a/Library/common/main.fmf
+++ b/Library/common/main.fmf
@@ -1,7 +1,8 @@
 summary: fapolicyd test library
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 require:
-- library(selinux-policy/common)
 - rpmdevtools
 - rpm-build
 - gcc
+- policycoreutils
+- selinux-policy-devel

--- a/Regression/run-through-ld/runtest.sh
+++ b/Regression/run-through-ld/runtest.sh
@@ -28,6 +28,7 @@
 . /usr/share/beakerlib/beakerlib.sh
 
 PACKAGE="fapolicyd"
+TEST_LS=/var/tmp/ls2
 
 rlJournalStart
   rlPhaseStartSetup && {
@@ -42,8 +43,8 @@ rlJournalStart
     CleanupRegister 'rlRun "fapCleanup"'
     rlRun "fapSetup"
     CleanupRegister 'rlRun "rlFileRestore"'
-    rlRun "rlFileBackup --clean /usr/bin/ls2"
-    rlRun "cp /usr/bin/ls /usr/bin/ls2"
+    rlRun "rlFileBackup --clean $TEST_LS"
+    rlRun "cp /usr/bin/ls $TEST_LS"
     CleanupRegister "rlRun 'fapServiceRestore'"
     rlRun "fapServiceStart"
   rlPhaseEnd; }
@@ -57,13 +58,13 @@ rlJournalStart
 
   rlPhaseStartTest "direct execution" && {
     rlRun "su -c '/usr/bin/ls -la' - $testUser"
-    rlRun "su -c '/usr/bin/ls2 -la' - $testUser" 126
+    rlRun "su -c '$TEST_LS -la' - $testUser" 126
   rlPhaseEnd; }
 
   rlPhaseStartTest "ld_so execution" && {
     ld_so=`readelf -e /usr/bin/bash | grep interpreter | sed 's/.$//' | rev | cut -d " " -f 1 | rev`
     rlRun "su -c '$ld_so /usr/bin/ls -la' - $testUser" 126
-    rlRun "su -c '$ld_so /usr/bin/ls2 -la' - $testUser" 126
+    rlRun "su -c '$ld_so $TEST_LS -la' - $testUser" 126
   rlPhaseEnd; }
 
   rlPhaseStartCleanup && {

--- a/Sanity/cli-options/runtest.sh
+++ b/Sanity/cli-options/runtest.sh
@@ -45,6 +45,12 @@ Update() {
 
 workaround=${workaround:-true}
 
+TESTDIR_ALL="/var/testdir/subdir"
+TESTDIR="/var/testdir/"
+TESTFILE_FIRST="/var/testfile"
+TESTFILE_SECOND="/var/testdir/testfile"
+TESTFILE_THIRD="/var/testdir/subdir/testfile"
+
 rlJournalStart && {
   rlPhaseStartSetup && {
     rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
@@ -59,11 +65,11 @@ rlJournalStart && {
     CleanupRegister 'rlRun "Stop"'
     rlRun "Start"
     CleanupRegister "rlFileRestore"
-    rlRun "rlFileBackup --clean /opt/testdir/ /opt/testfile"
-    rlRun "mkdir -p '/opt/testdir/subdir'"
-    rlRun "touch /opt/testfile"
-    rlRun "touch /opt/testdir/testfile"
-    rlRun "touch /opt/testdir/subdir/testfile"
+    rlRun "rlFileBackup --clean $TESTDIR $TESTFILE_FIRST"
+    rlRun "mkdir -p $TESTDIR_ALL"
+    rlRun "touch $TESTFILE_FIRST"
+    rlRun "touch $TESTFILE_SECOND"
+    rlRun "touch $TESTFILE_THIRD"
   rlPhaseEnd; }
 
   tcfTry "Tests" --no-assert && {
@@ -120,39 +126,39 @@ rlJournalStart && {
       tcfChk "file" && {
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertNotGrep "/opt/testfile" db_dump -E
+        rlAssertNotGrep "$TESTFILE_FIRST" db_dump -E
         $workaround && Start
-        rlRun "fapolicyd-cli -f add /opt/testfile"
+        rlRun "fapolicyd-cli -f add $TESTFILE_FIRST"
         Update
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertGrep "/opt/testfile" db_dump -E
+        rlAssertGrep "$TESTFILE_FIRST" db_dump -E
         $workaround && Start
-        rlRun "fapolicyd-cli -f delete /opt/testfile"
+        rlRun "fapolicyd-cli -f delete $TESTFILE_FIRST"
         Update
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertNotGrep "/opt/testfile" db_dump -E
+        rlAssertNotGrep "$TESTFILE_FIRST" db_dump -E
         $workaround && Start; :
       tcfFin; }
       tcfChk "directory" && {
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertNotGrep "/opt/testdir" db_dump -E
+        rlAssertNotGrep "$TESTDIR" db_dump -E
         #debugPrompt
         $workaround && Start
-        rlRun "fapolicyd-cli -f add /opt/testdir"
+        rlRun "fapolicyd-cli -f add $TESTDIR"
         Update
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertGrep "/opt/testdir/testfile" db_dump -E
-        rlAssertGrep "/opt/testdir/subdir/testfile" db_dump -E
+        rlAssertGrep "$TESTFILE_SECOND" db_dump -E
+        rlAssertGrep "$TESTFILE_THIRD" db_dump -E
         $workaround && Start
-        rlRun "fapolicyd-cli -f delete /opt/testdir"
+        rlRun "fapolicyd-cli -f delete $TESTDIR"
         Update
         $workaround && Stop
         rlRun "fapolicyd-cli -D >db_dump"
-        rlAssertNotGrep "/opt/testdir" db_dump -E
+        rlAssertNotGrep "$TESTDIR" db_dump -E
         $workaround && Start; :
       tcfFin; }
     rlPhaseEnd; }

--- a/Sanity/ld-path/main.fmf
+++ b/Sanity/ld-path/main.fmf
@@ -10,7 +10,6 @@ enabled: true
 tag:
   - CI-Tier-1
   - Tier1
-  - ImageMode
 tier: '1'
 adjust+:
   - enabled: false

--- a/Sanity/rules-d/main.fmf
+++ b/Sanity/rules-d/main.fmf
@@ -16,7 +16,6 @@ tag:
   - rhel-8.6.0
   - rhel-9.0.0
   - rhel-buildroot
-  - ImageMode
 tier: '1'
 adjust+:
   - enabled: false

--- a/Sanity/trust-db/main.fmf
+++ b/Sanity/trust-db/main.fmf
@@ -19,6 +19,7 @@ tag:
 - TIPfail
 - Tier2
 - rhel-8.3.0
+- ImageMode
 tier: '2'
 extra-summary: /CoreOS/fapolicyd/Sanity/trust-db
 extra-task: /CoreOS/fapolicyd/Sanity/trust-db

--- a/Sanity/trust-db/runtest.sh
+++ b/Sanity/trust-db/runtest.sh
@@ -31,6 +31,11 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="fapolicyd"
+TESTDIR_ALL="/var/testdir/subdir"
+TESTDIR="/var/testdir/"
+TESTFILE_FIRST="/var/testfile"
+TESTFILE_SECOND="/var/testdir/testfile"
+TESTFILE_THIRD="/var/testdir/subdir/testfile"
 
 Stop() {
   fapStop
@@ -67,11 +72,11 @@ rlJournalStart && {
       rlRun "rm -f /etc/fapolicyd/rules.d/*"
     }
     CleanupRegister "rlFileRestore"
-    rlRun "rlFileBackup --clean /opt/testdir/ /opt/testfile"
-    rlRun "mkdir -p '/opt/testdir/subdir'"
-    rlRun "touch /opt/testfile"
+    rlRun "rlFileBackup --clean $TESTDIR $TESTFILE_FIRST"
+    rlRun "mkdir -p '$TESTDIR_ALL'"
+    rlRun "touch $TESTFILE_FIRST"
     rlRun "echo 'allow perm=any all : all' > /etc/fapolicyd/fapolicyd.rules"
-    rlRun "fapolicyd-cli -f add /opt/testfile"
+    rlRun "fapolicyd-cli -f add $TESTFILE_FIRST"
   rlPhaseEnd; }
 
   tcfTry "Tests" --no-assert && {
@@ -158,7 +163,7 @@ rlJournalStart && {
     rlPhaseEnd; }
 
     rlPhaseStartTest "config option trust=file, while db is empty" && {
-      rlRun "fapolicyd-cli -f delete /opt/testfile"
+      rlRun "fapolicyd-cli -f delete $TESTFILE_FIRST"
       Trust 'file'
       CleanupRegister --mark 'rlRun "Stop"'
       rlRun "Start"


### PR DESCRIPTION
library use from selinux-policy common just two simple function which could be rewritten inside fapolicyd library and library dont need dependecy then. Ublock image mode testing for fapolicyd.