### PR TITLE
Regression/RHEL-69136: New test on adding sockets to trust database

### DIFF
--- a/Regression/RHEL-69136-crash-on-adding-non-regular-file/main.fmf
+++ b/Regression/RHEL-69136-crash-on-adding-non-regular-file/main.fmf
@@ -1,0 +1,17 @@
+summary: Verify that fapolicyd does not crash on adding directory with sockets to trust database
+contact: Natália Bubáková <nbubakov@redhat.com>
+test: ./runtest.sh
+duration: 5m
+enabled: true
+recommend+:
+  - socat
+  - library(ControlFlow/Cleanup)
+tag:
+  - Tier3
+tier: '3'
+adjust+:
+  - enabled: false
+    when: distro < rhel-9.7
+    continue: false
+links:
+  - verifies: https://issues.redhat.com/browse/RHEL-69136

--- a/Regression/RHEL-69136-crash-on-adding-non-regular-file/runtest.sh
+++ b/Regression/RHEL-69136-crash-on-adding-non-regular-file/runtest.sh
@@ -49,10 +49,11 @@ rlJournalStart
 
         CleanupRegister 'rlRun "killall -9 socat" 0-255'
         rlRun "socat UNIX-LISTEN:"./socket_dir/socket" /dev/null &"
+        rlRun "sleep 3"
         CleanupRegister 'rlRun "fapolicyd-cli -f delete ./socket_dir" 0-255'
         rlRun -s "fapolicyd-cli -f add ./socket_dir" 0 "Add a directory with a socket to trust database"
-        rlAssertNotGrep "Segmentation fault (core dumped)" $rlRun_LOG
-        rlRun "fapolicyd-cli --dump-db | grep ~/socket_dir" 0 "Verify that the socket directory is in trust database"
+        rlAssertNotGrep "Segmentation fault[[:space:]]+\(core dumped\)" $rlRun_LOG -E
+        rlRun "fapolicyd-cli --dump-db | grep ${TmpDir}/socket_dir" 0 "Verify that the socket directory is in trust database"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/Regression/RHEL-69136-crash-on-adding-non-regular-file/test.sh
+++ b/Regression/RHEL-69136-crash-on-adding-non-regular-file/test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /fapolicyd/Regression/RHEL-69136-crash-on-adding-non-regular-file
+#   Description: Verify that fapolicyd does not crash on adding directory with sockets to trust database
+#   Author: Natália Bubáková <nbubakov@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2024 Red Hat, Inc.
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 2 of
+#   the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE.  See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see http://www.gnu.org/licenses/.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/bin/rhts-environment.sh || :
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
+        CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        CleanupRegister 'rlRun "popd"'
+        rlRun "pushd $TmpDir"
+        CleanupRegister 'rlRun "fapCleanup"'
+        rlRun "fapSetup"
+        CleanupRegister 'rlRun "fapStop"'
+        rlRun "fapStart"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        CleanupRegister 'rlRun "rm -rf ./socket_dir"'
+        mkdir -p ./socket_dir
+
+        CleanupRegister 'rlRun "killall -9 socat" 0-255'
+        rlRun "socat UNIX-LISTEN:"./socket_dir/socket" /dev/null &"
+        CleanupRegister 'rlRun "fapolicyd-cli -f delete ./socket_dir" 0-255'
+        rlRun -s "fapolicyd-cli -f add ./socket_dir" 0 "Add a directory with a socket to trust database"
+        rlAssertNotGrep "Segmentation fault (core dumped)" $rlRun_LOG
+        rlRun "fapolicyd-cli --dump-db | grep ~/socket_dir" 0 "Verify that the socket directory is in trust database"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        CleanupDo
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
## Summary by Sourcery

Introduce a regression test for RHEL-69136 to ensure fapolicyd-cli handles non-regular files without crashing when adding directories with sockets to the trust database.

Tests:
- Add a test script under Regression/RHEL-69136 that creates a UNIX socket in a directory, adds it to the trust database, asserts no crash, and verifies the entry.
- Add an FMF metadata file for the new regression test.