### PR TITLE
Mv requried buildroot pkg to recommend

### DIFF
--- a/Regression/bz1747494-suspicious-logs-on-service-start/main.fmf
+++ b/Regression/bz1747494-suspicious-logs-on-service-start/main.fmf
@@ -7,6 +7,7 @@ require+:
 - sed
 - dnf
 - gcc-c++
+recommend:
 - lmdb-devel
 duration: 5m
 enabled: true

--- a/Regression/static-apps/main.fmf
+++ b/Regression/static-apps/main.fmf
@@ -7,6 +7,7 @@ require+:
   - library(distribution/testUser)
   - /usr/bin/readelf
   - gcc
+recommend:
   - glibc-static
 duration: 5m
 enabled: true


### PR DESCRIPTION
## Summary by Sourcery

Relax buildroot package dependency by marking it as recommended rather than required in regression test metadata

Enhancements:
- Change buildroot dependency from required to recommended in Regression/bz1747494-suspicious-logs-on-service-start/main.fmf
- Change buildroot dependency from required to recommended in Regression/static-apps/main.fmf