### PR TITLE
removed the memleaks test from the CI set

### DIFF
--- a/Sanity/memleaks/main.fmf
+++ b/Sanity/memleaks/main.fmf
@@ -12,7 +12,6 @@ duration: 60m
 enabled: true
 tag:
   - Tier2
-  - CI-Tier-1
 tier: 2
 adjust+:
   - enabled: false


### PR DESCRIPTION
the test was an important part of the rebase testing at that time. It is part of the Tier2 set, thus there's no need to keep it in the CI as well.

## Summary by Sourcery

Remove the redundant memleaks test from the continuous integration suite.

CI:
- Exclude the memleaks test from the CI test set

Chores:
- Remove memleaks test from the CI configuration