### PR TITLE
Sanity/fapolicyd-files-ownership: Relevancy adjustment (RHEL-59626, RHEL-94536)

### DIFF
--- a/Sanity/fapolicyd-files-ownership/runtest.sh
+++ b/Sanity/fapolicyd-files-ownership/runtest.sh
@@ -68,7 +68,7 @@ rlJournalStart
         checkFile /var/log/fapolicyd-access.log fapolicyd fapolicyd
 
         # check /run files
-        checkFile -e /run/fapolicyd root fapolicyd
+        ( ! rlIsRHEL "<9.7" && ! rlIsRHEL "10.0" && ! rlIsFedora ) && checkFile -e /run/fapolicyd root fapolicyd
         checkFile -e /run/fapolicyd/fapolicyd.fifo root fapolicyd
 
         # check /usr files

--- a/Sanity/fapolicyd-files-ownership/runtest.sh
+++ b/Sanity/fapolicyd-files-ownership/runtest.sh
@@ -40,7 +40,7 @@ function checkFile() {
     GROUP=$3
     if "$MUSTEXIST" || [ -e "$FILEPATH" ]; then
         ls -ld $FILEPATH
-        rlRun "ls -ld $FILEPATH | grep -qE '$OWNER[ ]*$GROUP'"
+        rlRun "ls -ld $FILEPATH | grep -qE '$OWNER[ ]*$GROUP'" 0 "Check ownership of $FILEPATH ($OWNER:$GROUP)"
     fi
 }
 
@@ -48,7 +48,7 @@ rlJournalStart
 
     rlPhaseStartTest
         rlServiceStart fapolicyd
-        rlRun "systemctl status fapolicyd" 0 "Confirm that fapolicyd is running"
+        rlRun "rlServiceStatus fapolicyd" 0 "Confirm that fapolicyd is running"
 
         rlRun -s "id fapolicyd"
         PATTERN="[0-9]+\(fapolicyd\)"


### PR DESCRIPTION
## Summary by Sourcery

Adjust test scripts to improve logging, enforce version-specific file checks, and enable overlay support by modifying fapolicyd.conf

Enhancements:
- Add descriptive labels to ownership assertions and switch to rlServiceStatus in sanity tests
- Limit /run/fapolicyd file existence check to RHEL versions 9.7+ or 10.1+
- Backup and tweak watch_fs in fapolicyd.conf to include overlay for image mode in regression tests