### PR TITLE
Fix /Sanity/cli-options failures on Fedora

### DIFF
--- a/Sanity/cli-options/runtest.sh
+++ b/Sanity/cli-options/runtest.sh
@@ -167,11 +167,7 @@ rlJournalStart && {
       rlRun "cp '$(rpm -qal | grep '\.pyc$' | head -n 1)' files/application_x-bytecode.python_.pyc"
       rlRun "cp '$(rpm -qal | grep '\.so$' | grep -v libc | grep -v pthread | head -n 1)' files/application_x-sharedlib_non-libc.so"
       rlRun "cp /bin/bash files/application_x-executable_bash"
-      if rlIsRHELLike '>=9.6' || rlIsCentOS '>8'; then
-        libc=$(rpm -ql glibc | grep -E '^(/usr)?/lib(64)?/libc\b.*\.so(\.[0-9]+)?$' | head -n1)
-      else
-        libc=$(rpm -ql glibc | grep -E '^/lib(64)?/libc\b.*\.so(\.[0-9]+)?$' | head -n1)
-      fi
+      libc=$(rpm -ql glibc | grep -E '^(/usr)?/lib(64)?/libc\b.*\.so(\.[0-9]+)?$' | head -n1)
       tcfChk "checking $libc for application/x-sharedlib" && {
         echo -n "file's output:      "; file --mime $libc
         echo -n "fapolicyd's output: "; fapolicyd-cli -t $libc | tee out


### PR DESCRIPTION
- not all .pyc files are application/x-bytecode.python
- Fedora uses /usr/lib64 in the same way as RHEL, the only /lib64 is in old RHELs but there's a way how to match both using one regexp

## Summary by Sourcery

Fix cli-options tests on Fedora by using a mime-based lookup for .pyc files and consolidating libc path regex to handle /usr/lib64 consistently

Bug Fixes:
- Use file --mime to select a .pyc file with application/x-bytecode.python to account for varying mime types
- Unify libc path detection with a single regex to match /usr/lib64 on Fedora and other RHEL-like systems

Tests:
- Update runtest.sh to improve file selection logic for .pyc and simplify library path matching