### PR TITLE
Temporary disable /Sanity/fapolicyd-files-ownership

### DIFF
--- a/Sanity/fapolicyd-files-ownership/main.fmf
+++ b/Sanity/fapolicyd-files-ownership/main.fmf
@@ -8,7 +8,7 @@ framework: beakerlib
 recommend:
   - usbguafapolicydrd
 duration: 5m
-enabled: true
+enabled: false
 tag:
   - CI-Tier-1
   - Tier1


### PR DESCRIPTION
- contains typo:

    recommend:
       - usbguafapolicydrd

- what is the source of truth? i.e. all entries in /usr/share are root:root, why it's expected that /usr/share/fapolicyd is root:fapolicyd?

## Summary by Sourcery

Temporarily disable the Sanity/fapolicyd-files-ownership test due to a typo in the recommended script name and an unclear ownership assumption for /usr/share/fapolicyd files.

Tests:
- Disable the fapolicyd-files-ownership Sanity check.

Chores:
- Comment out or remove the Sanity/fapolicyd-files-ownership/main.fmf test file.