### PR TITLE
require the setools-console package before running the sesearch tool

### DIFF
--- a/Library/common/main.fmf
+++ b/Library/common/main.fmf
@@ -6,3 +6,4 @@ require:
 - gcc
 - policycoreutils
 - selinux-policy-devel
+- setools-console


### PR DESCRIPTION
The fapSetup function calls the sesearch command, but the setools-console package, which brings the command, is not mentioned among required or recommended packages. This situation leads to an error which is visible during test executions:

.../libs/fapolicyd-tests/Library/common/lib.sh: line 73: sesearch: command not found

From now on, the setools-console package is required.