### PR TITLE
Return scriptlet comment back to have functional sed in test

### DIFF
--- a/Library/common/lib.sh
+++ b/Library/common/lib.sh
@@ -265,6 +265,8 @@ install -m 755 fapTestProgram %{buildroot}${__INTERNAL_program_dir}/fapTestProgr
 %files
 ${__INTERNAL_program_dir}/fapTestProgram
 
+#scriptlet
+
 # Add a proper entry to fix the warning
 %changelog
 * Fri Jul 25 2025 X Y <test@example.com> - 1-1


### PR DESCRIPTION
In previous change scriptlet was accidentaly removed, return it back to have functional sed in scenario. [1]

[1] https://github.com/RedHat-SP-Security/fapolicyd-tests/commit/5f900187b59beaee44303583f2c53445b6a1964a#diff-74c0fb075f82834a05e38d09f03d5f8fea9f875bc48525e91d87e3822e6f9efdL286

## Summary by Sourcery

Bug Fixes:
- Re-add the "#scriptlet" comment block that was accidentally removed